### PR TITLE
Let the HTTP status text in the Fiddler input be optional

### DIFF
--- a/lib/http-parser.js
+++ b/lib/http-parser.js
@@ -1,3 +1,5 @@
+const http = require("http");
+
 function HttpParser() {
     this.request = "";
     this.response = "";
@@ -82,13 +84,13 @@ HttpParser.prototype.parseResponse = function (response) {
         if (i === 0) {
             //https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html
             //The first line of a Response message is the Status-Line, consisting of the protocol version followed by a numeric status code and its associated textual phrase, with each element separated by SP characters.
-            const firstLinePairs = header.match(/^(.+)\s(\d+)\s(.+)$/);
+            const firstLinePairs = header.match(/^(.+)\s(\d+)(?:\s(.+))?$/);
+            const code = parseInt(firstLinePairs[2], 10);
 
             responseProtocol = firstLinePairs[1];
-
             responseStatus = {
-                code: parseInt(firstLinePairs[2], 10),
-                message: firstLinePairs[3]
+                code: code,
+                message: firstLinePairs[3] || http.STATUS_CODES[code]
             };
 
             return true;


### PR DESCRIPTION
Some Fiddler logs contain only the HTTP status code without text.