### PR TITLE
Add option to disable validation of the output HAR file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # saz2har
 
-Convert SAZ file (from Fiddler) to HAR file.
+Converts SAZ file (from Fiddler) to HAR file (for Chrome).
 
 ## Install
 
@@ -10,18 +10,39 @@ $ npm install saz2har
 
 ## API
 
+### convert(input, [output], [options])
+
+* `input` - path to the input .saz file
+* `output` - path to the output .har file
+* `options` - object with conversion options
+  * `validate` - enables validation of the the HAR output (default: `true`)
+
 ```js
 var saz2har = require("saz2har");
 
 saz2har.convert("tmp/log.saz", function (err, data) {
     if (err) {
         console.error("Error: ", err);
-
         return;
     }
-
     console.log(data);
 });
+```
+
+## Tool
+
+```
+$ saz2har --help
+
+Usage: saz2har [options] input.saz [output.har]
+
+Options:
+  --help         Show help                                     [boolean]
+  --version      Show version                                  [boolean]
+  --no-validate  Validate the output HAR file (default: true)  [boolean]
+
+Examples:
+  saz2har foo.saz bar.har --no-validate
 ```
 
 ## License

--- a/bin.js
+++ b/bin.js
@@ -2,14 +2,25 @@
 
 const path = require("path");
 
-const argv = require("yargs").argv;
+const argv = require("yargs")
+    .usage(`Converts SAZ file (from Fiddler) to HAR file (for Chrome).
+
+Usage: $0 [options] input.saz [output.har]`)
+    .option('no-validate', {
+        type: 'boolean',
+        description: 'Validate the output HAR file (default: true)'
+    })
+    .example('$0 foo.saz bar.har --no-validate')
+    .argv;
+console.log('***', argv.validate)
 const saz2har = require("./");
 
 const sourceFile = argv.source || argv.s || argv._[0];
 const destinationFile = argv.destination || argv.d || argv._[1];
 
 const options = {
-    write: true
+    write: true,
+    validate: argv.validate
 };
 
 const callback = (err, data) => {

--- a/bin.js
+++ b/bin.js
@@ -12,7 +12,7 @@ Usage: $0 [options] input.saz [output.har]`)
     })
     .example('$0 foo.saz bar.har --no-validate')
     .argv;
-console.log('***', argv.validate)
+
 const saz2har = require("./");
 
 const sourceFile = argv.source || argv.s || argv._[0];

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -16,7 +16,8 @@ function Converter(options) {
     this.destinationFilename = "";
 
     this.DEFAULT_OPTIONS = {
-        write: false
+        write: false,
+        validate: true
     };
 
     this.FILENAME_EXTENSION = {
@@ -45,7 +46,9 @@ Converter.prototype.convert = function (sourceFilename, destinationFilename) {
     });
 
     sazParser.on("parse", (data) => {
-        const harBuilder = new HarBuilder();
+        const harBuilder = new HarBuilder({
+            validate: this.options.validate
+        });
 
         harBuilder.on("error", (err) => {
             this.emit("error", err);
@@ -101,7 +104,9 @@ Converter.prototype._setOptions = function (options) {
 };
 
 Converter.prototype._setOption = function (key, value) {
-    this.options[key] = value;
+    if (value !== undefined) {
+        this.options[key] = value;
+    }
 };
 
 Converter.prototype._setSources = function (sourceFilename, destinationFilename) {

--- a/lib/har-builder.js
+++ b/lib/har-builder.js
@@ -32,7 +32,7 @@ function patchBuffer() {
 
 patchBuffer();
 
-function HarBuilder() {
+function HarBuilder(options) {
     this.HAR_VERSION = "1.2";
 
     this.FIDDLER_SESSION_TIMERS = [
@@ -55,6 +55,8 @@ function HarBuilder() {
     this.DEFAULT_CHARSET = "utf-8";
 
     this.END_OF_HTTP_HEADER = "\r\n\r\n";
+
+    this.options = Object.assign({ validate: true }, options);
 
     this.har = {
         log: {
@@ -111,8 +113,11 @@ HarBuilder.decodeChunks = function (data) {
 
 HarBuilder.prototype.build = function (data) {
     this._parseQueries(data);
-
-    this._validate();
+    if (this.options.validate) {
+        this._validate();
+    } else {
+        this._done();
+    }
 };
 
 HarBuilder.prototype._parseQueries = function (queries) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "saz2har",
     "version": "2.2.1",
-    "description": "Convert SAZ file (from Fiddler) to HAR file",
+    "description": "Converts SAZ file (from Fiddler) to HAR file (for Chrome).",
     "author": {
         "name": "Alexander Myadzel",
         "email": "myadzel@gmail.com"


### PR DESCRIPTION
Even the latest version of har-validator does not accept the cookie expiration times. It is probably a problem of the JSON Schema validator.

The validation schema in har-validator does not declare the required propeties properly and makes the whole validation fail. I should want to look at it later.